### PR TITLE
Rename DescibeSecondary to DescribeSecondary

### DIFF
--- a/ValueSequencer/CHexagramValueSequencer.cs
+++ b/ValueSequencer/CHexagramValueSequencer.cs
@@ -220,7 +220,7 @@ namespace ValueSequencer
 			return HexagramId() + " " + Label + (bValue ? " (" + ValueStr + ")" : "");
 		}
 
-		public String DescibeSecondary(bool bValue = false)
+		public String DescribeSecondary(bool bValue = false)
 		{
 			if (IsMoving)
 			{
@@ -234,7 +234,7 @@ namespace ValueSequencer
 
 		public String DescribeCast(bool bValue = false)
 		{
-			return DescribePrimary(bValue) + (IsMoving ? " > " + DescibeSecondary(bValue) : "");
+			return DescribePrimary(bValue) + (IsMoving ? " > " + DescribeSecondary(bValue) : "");
 		}
 
 		protected override int GetCurrentSequence() { return m_nCurrentSequence; }


### PR DESCRIPTION
## Summary
- Fix typo in hexagram value sequencer by renaming `DescibeSecondary` to `DescribeSecondary`
- Update `DescribeCast` to call the new method name

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaddc2760c832bb15d2fdc114fc246