### PR TITLE
Simplify hexagram copy constructor with loops

### DIFF
--- a/ValueSequencer/CHexagramValueSequencer.cs
+++ b/ValueSequencer/CHexagramValueSequencer.cs
@@ -18,32 +18,20 @@ namespace ValueSequencer
 			//UpdateOuterValues();
 		}
 
-		public CHexagramValueSequencer(ref CHexagramValueSequencer hvs) : this(0)
-		{
-			Trigram(1).Line(2).Value = hvs.Trigram(1).Line(2).Value;
-			Trigram(1).Line(1).Value = hvs.Trigram(1).Line(1).Value;
-			Trigram(1).Line(0).Value = hvs.Trigram(1).Line(0).Value;
-			Trigram(0).Line(2).Value = hvs.Trigram(0).Line(2).Value;
-			Trigram(0).Line(1).Value = hvs.Trigram(0).Line(1).Value;
-			Trigram(0).Line(0).Value = hvs.Trigram(0).Line(0).Value;
+               public CHexagramValueSequencer(ref CHexagramValueSequencer hvs) : this(0)
+               {
+                       for (int t = 0; t < 2; ++t)
+                               for (int l = 0; l < 3; ++l)
+                               {
+                                       var line = Trigram(t).Line(l);
+                                       line.Value = hvs.Trigram(t).Line(l).Value;
+                                       line.UpdateInnerValues();
+                                       line.UpdateOuterValues();
+                               }
 
-			Trigram(1).Line(2).UpdateInnerValues();
-			Trigram(1).Line(1).UpdateInnerValues();
-			Trigram(1).Line(0).UpdateInnerValues();
-			Trigram(0).Line(2).UpdateInnerValues();
-			Trigram(0).Line(1).UpdateInnerValues();
-			Trigram(0).Line(0).UpdateInnerValues();
-
-			Trigram(1).Line(2).UpdateOuterValues();
-			Trigram(1).Line(1).UpdateOuterValues();
-			Trigram(1).Line(0).UpdateOuterValues();
-			Trigram(0).Line(2).UpdateOuterValues();
-			Trigram(0).Line(1).UpdateOuterValues();
-			Trigram(0).Line(0).UpdateOuterValues();
-
-			//UpdateInnerValues();
-			//UpdateOuterValues();
-		}
+                       //UpdateInnerValues();
+                       //UpdateOuterValues();
+               }
 
 		public CTrigramValueSequencer Trigram(int nIndex)
 		{


### PR DESCRIPTION
## Summary
- replace explicit line copy and update logic with trigram/line loops in `CHexagramValueSequencer`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aae02b3790832bb29ee964b97b21a0