### PR TITLE
Add test for Hexagram copy constructor

### DIFF
--- a/Test2.Tests/HexagramCopyConstructorTests.cs
+++ b/Test2.Tests/HexagramCopyConstructorTests.cs
@@ -1,0 +1,46 @@
+using ValueSequencer;
+using Xunit;
+
+namespace Test2.Tests;
+
+public class HexagramCopyConstructorTests
+{
+    [Fact]
+    public void CopyConstructor_CreatesIndependentCopy()
+    {
+        var original = new CHexagramValueSequencer(42);
+
+        var originalValues = new int[2, 3];
+        for (int t = 0; t < 2; t++)
+        {
+            for (int l = 0; l < 3; l++)
+            {
+                originalValues[t, l] = original.Trigram(t).Line(l).Value;
+            }
+        }
+
+        var copy = new CHexagramValueSequencer(ref original);
+
+        for (int t = 0; t < 2; t++)
+        {
+            for (int l = 0; l < 3; l++)
+            {
+                Assert.Equal(originalValues[t, l], copy.Trigram(t).Line(l).Value);
+            }
+        }
+
+        var line = original.Trigram(0).Line(0);
+        line.Value = line.Value == 1 ? 2 : 1;
+        line.UpdateInnerValues();
+        line.UpdateOuterValues();
+
+        Assert.NotEqual(originalValues[0, 0], original.Trigram(0).Line(0).Value);
+        for (int t = 0; t < 2; t++)
+        {
+            for (int l = 0; l < 3; l++)
+            {
+                Assert.Equal(originalValues[t, l], copy.Trigram(t).Line(l).Value);
+            }
+        }
+    }
+}

--- a/Test2.Tests/Test2.Tests.csproj
+++ b/Test2.Tests/Test2.Tests.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../Test2/Test2.csproj" />
+    <ProjectReference Include="../ValueSequencer/ValueSequencer.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add unit test validating CHexagramValueSequencer copy constructor creates deep independent copy
- reference ValueSequencer project in test project

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aae2291200832b869a0be6dc989107