### PR TITLE
Use strongly typed hexagram array

### DIFF
--- a/ValueSequencer/CHexagramSequences.cs
+++ b/ValueSequencer/CHexagramSequences.cs
@@ -50,28 +50,28 @@ namespace ValueSequencer
 				}
 				hvsPrimary.Next();
 			}
-			Array.Sort(m_arrHexagram);
-		}
+                        Array.Sort<CHexagram>(m_arrHexagram);
+                }
 
-		public void Add(ref CHexagramValueSequencer hvsPrimary)
-		{
-			m_arrHexagram.SetValue(new CHexagram(ref hvsPrimary),++m_nCount);
-		}
+                public void Add(ref CHexagramValueSequencer hvsPrimary)
+                {
+                        m_arrHexagram[++m_nCount] = new CHexagram(ref hvsPrimary);
+                }
 
-		public CHexagramArray MultiCast(int nCount)
-		{
-			CHexagramValueSequencer hvs = new CHexagramValueSequencer(63); // more even ????????
-			for (int i = 0; i < nCount; ++i)
-			{
-				//CHexagramValueSequencer hvs = new CHexagramValueSequencer(63);
-				AutoCast(ref hvs);
-				CHexagram h = new CHexagram(ref hvs);
-				int nIndex = Array.BinarySearch(m_arrHexagram, h);
-				if(nIndex >= 0)
-					((CHexagram) m_arrHexagram.GetValue(nIndex)).Add();
-			}
-			return this;
-		}
+                public CHexagramArray MultiCast(int nCount)
+                {
+                        CHexagramValueSequencer hvs = new CHexagramValueSequencer(63); // more even ????????
+                        for (int i = 0; i < nCount; ++i)
+                        {
+                                //CHexagramValueSequencer hvs = new CHexagramValueSequencer(63);
+                                AutoCast(ref hvs);
+                                CHexagram h = new CHexagram(ref hvs);
+                                int nIndex = Array.BinarySearch<CHexagram>(m_arrHexagram, h);
+                                if(nIndex >= 0)
+                                        m_arrHexagram[nIndex].Add();
+                        }
+                        return this;
+                }
 
 		public CHexagramValueSequencer AutoCast(ref CHexagramValueSequencer hvs) //////// Random ?????????????????????????????
 		{
@@ -90,11 +90,11 @@ namespace ValueSequencer
 			throw new NotImplementedException();
 		}
 
-		public Array HexagramArray() => m_arrHexagram;
-		public CHexagram this[int i] => (CHexagram) m_arrHexagram.GetValue(i);
+                public CHexagram[] HexagramArray() => m_arrHexagram;
+                public CHexagram this[int i] => m_arrHexagram[i];
 
-		private Array m_arrHexagram = Array.CreateInstance(typeof(CHexagram), 4096);
-		private int m_nCount = -1;
-	}
+                private CHexagram[] m_arrHexagram = new CHexagram[4096];
+                private int m_nCount = -1;
+        }
 	
 }


### PR DESCRIPTION
## Summary
- use `CHexagram[]` instead of `Array` for hexagram storage
- update Add, MultiCast, and indexer to work with typed array
- switch BinarySearch to generic version for hexagram lookups

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ab06fe35b8832ba5a6e744643e2fe1